### PR TITLE
Refactor TypeConverter using strategy pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # codex_ki_test
-This project is used to test how the AI is worth for programming issues. 
+
+This project demonstrates a small XML editing framework written in Java. The
+framework is located under `src/main/java/xmlframework` and provides simple
+methods to add, update or remove elements with automatic type conversion.
+
+## Building and running
+
+Compile the example using `javac` and run it with `java`:
+
+```bash
+javac -d out $(find src/main/java -name '*.java')
+java -cp out xmlframework.Example
+```
+
+Running the example will create `example.xml` in the project directory.

--- a/src/main/java/xmlframework/Example.java
+++ b/src/main/java/xmlframework/Example.java
@@ -1,0 +1,20 @@
+package xmlframework;
+
+import java.nio.file.Paths;
+
+public class Example {
+    public static void main(String[] args) throws Exception {
+        XmlEditor editor = XmlEditor.newDocument("person");
+
+        editor.addElement("/person", "name", "Alice");
+        editor.addElement("/person", "age", 30);
+
+        Integer age = editor.getValue("/person/age", Integer.class);
+        System.out.println("Age: " + age);
+
+        editor.updateValue("/person/name", "Bob");
+        editor.delete("/person/age");
+
+        editor.save(Paths.get("example.xml"));
+    }
+}

--- a/src/main/java/xmlframework/TypeConverter.java
+++ b/src/main/java/xmlframework/TypeConverter.java
@@ -1,0 +1,43 @@
+package xmlframework;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class TypeConverter {
+    private static final Map<Class<?>, Function<String, ?>> STRATEGIES = new HashMap<>();
+
+    static {
+        STRATEGIES.put(String.class, s -> s);
+        STRATEGIES.put(Integer.class, Integer::valueOf);
+        STRATEGIES.put(int.class, Integer::valueOf);
+        STRATEGIES.put(Long.class, Long::valueOf);
+        STRATEGIES.put(long.class, Long::valueOf);
+        STRATEGIES.put(Double.class, Double::valueOf);
+        STRATEGIES.put(double.class, Double::valueOf);
+        STRATEGIES.put(Boolean.class, Boolean::valueOf);
+        STRATEGIES.put(boolean.class, Boolean::valueOf);
+    }
+
+    private TypeConverter() {}
+
+    public static <T> String toString(T value) {
+        return value == null ? null : value.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T fromString(String value, Class<T> type) {
+        if (value == null) {
+            return null;
+        }
+        Function<String, ?> func = STRATEGIES.get(type);
+        if (func != null) {
+            return (T) func.apply(value);
+        }
+        throw new IllegalArgumentException("Unsupported type: " + type);
+    }
+
+    public static <T> void registerConverter(Class<T> type, Function<String, T> converter) {
+        STRATEGIES.put(type, converter);
+    }
+}

--- a/src/main/java/xmlframework/XmlEditor.java
+++ b/src/main/java/xmlframework/XmlEditor.java
@@ -1,0 +1,88 @@
+package xmlframework;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+public class XmlEditor {
+    private final Document document;
+    private final XPath xpath = XPathFactory.newInstance().newXPath();
+
+    private XmlEditor(Document document) {
+        this.document = document;
+    }
+
+    public static XmlEditor newDocument(String rootName) throws Exception {
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = builder.newDocument();
+        Element root = doc.createElement(rootName);
+        doc.appendChild(root);
+        return new XmlEditor(doc);
+    }
+
+    public static XmlEditor fromFile(Path path) throws Exception {
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = builder.parse(Files.newInputStream(path));
+        return new XmlEditor(doc);
+    }
+
+    public void save(Path path) throws IOException, TransformerException {
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.transform(new DOMSource(document), new StreamResult(Files.newOutputStream(path)));
+    }
+
+    public <T> void addElement(String parentXPath, String name, T value) throws XPathExpressionException {
+        Node parent = (Node) xpath.evaluate(parentXPath, document, XPathConstants.NODE);
+        if (parent == null) {
+            throw new IllegalArgumentException("Parent not found: " + parentXPath);
+        }
+        Element element = document.createElement(name);
+        element.setTextContent(TypeConverter.toString(value));
+        parent.appendChild(element);
+    }
+
+    public <T> T getValue(String elementXPath, Class<T> type) throws XPathExpressionException {
+        Node node = (Node) xpath.evaluate(elementXPath, document, XPathConstants.NODE);
+        if (node == null) {
+            return null;
+        }
+        return TypeConverter.fromString(node.getTextContent(), type);
+    }
+
+    public <T> void updateValue(String elementXPath, T value) throws XPathExpressionException {
+        Node node = (Node) xpath.evaluate(elementXPath, document, XPathConstants.NODE);
+        if (node == null) {
+            throw new IllegalArgumentException("Element not found: " + elementXPath);
+        }
+        node.setTextContent(TypeConverter.toString(value));
+    }
+
+    public void delete(String elementXPath) throws XPathExpressionException {
+        Node node = (Node) xpath.evaluate(elementXPath, document, XPathConstants.NODE);
+        if (node == null) {
+            throw new IllegalArgumentException("Element not found: " + elementXPath);
+        }
+        Node parent = node.getParentNode();
+        if (parent != null) {
+            parent.removeChild(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace conditional logic in `TypeConverter.fromString` with a strategy map
- allow custom converter registration

## Testing
- `javac -d out $(find src/main/java -name '*.java')`
- `java -cp out xmlframework.Example`

------
https://chatgpt.com/codex/tasks/task_e_688393d9cb308326816cd12a6050a51b