### PR TITLE
Add XmlEditor.toXmlString utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ java -cp out xmlframework.Example
 ```
 
 Running the example will create `example.xml` in the project directory.
+
+The `XmlEditor` also provides `toXmlString()` to retrieve the current
+document as a formatted string without saving it to disk.

--- a/src/main/java/xmlframework/Example.java
+++ b/src/main/java/xmlframework/Example.java
@@ -15,6 +15,7 @@ public class Example {
         editor.updateValue("/person/name", "Bob");
         editor.delete("/person/age");
 
+        System.out.println(editor.toXmlString());
         editor.save(Paths.get("example.xml"));
     }
 }

--- a/src/main/java/xmlframework/XmlEditor.java
+++ b/src/main/java/xmlframework/XmlEditor.java
@@ -3,6 +3,7 @@ package xmlframework;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.io.StringWriter;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -84,5 +85,19 @@ public class XmlEditor {
         if (parent != null) {
             parent.removeChild(node);
         }
+    }
+
+    /**
+     * Returns the current document as an indented XML string.
+     *
+     * @return XML representation of the document
+     * @throws TransformerException if the transformation fails
+     */
+    public String toXmlString() throws TransformerException {
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        StringWriter writer = new StringWriter();
+        transformer.transform(new DOMSource(document), new StreamResult(writer));
+        return writer.toString();
     }
 }


### PR DESCRIPTION
## Summary
- add a new `toXmlString()` method to `XmlEditor`
- print generated XML in the example using the new method
- mention `toXmlString()` in the README

## Testing
- `javac -d out $(find src/main/java -name '*.java')`
- `java -cp out xmlframework.Example`

------
https://chatgpt.com/codex/tasks/task_e_68839cfccb0083269c563ca4d4b8aea2